### PR TITLE
Upgrade golangci-lint to v1.49.0

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -18,4 +18,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.45.2
+          version: v1.49.0


### PR DESCRIPTION
To resolve some issues around linting around generics

Signed-off-by: Ed Warnicke <hagbard@gmail.com>
