### PR TITLE
fix: Use personal bot token for automerge job

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -20,5 +20,5 @@ jobs:
         with:
           GITHUB_LOGIN: nsmbot
           ENABLED_FOR_MANUAL_CHANGES: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}
           MAXIMUM_RETRIES: 25


### PR DESCRIPTION
Signed-off-by: denis-tingaikin <denis.tingajkin@xored.com>

This should fix a problem with merging PRs from the NSM bot.

Related to https://github.com/ridedott/merge-me-action/issues/1581