### PR TITLE
Specify images platforms to avoid using default platforms that depend on the runner

### DIFF
--- a/.github/workflows/docker-push-ghcr.yaml
+++ b/.github/workflows/docker-push-ghcr.yaml
@@ -33,5 +33,6 @@ jobs:
         with:
           file: Dockerfile
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.metaci.outputs.tags }}

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -34,4 +34,5 @@ jobs:
           file: Dockerfile
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: "ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}:${{ inputs.tag }}"


### PR DESCRIPTION
## Motivation

Fixes https://github.com/networkservicemesh/deployments-k8s/issues/9215