### PR TITLE
Fix setup-protoc action for sdk-gogenerate

### DIFF
--- a/.github/workflows/sdk-gogenerate.yaml
+++ b/.github/workflows/sdk-gogenerate.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: arduino/setup-protoc@master
+      - uses: arduino/setup-protoc@v1
         with:
           version: '3.8.0'
       - uses: actions/setup-go@v1


### PR DESCRIPTION
The action is failing because we are using `master` tag and there was a breaking change in the upstream.

```log
Run arduino/setup-protoc@master
  with:
    version: [3](https://github.com/networkservicemesh/sdk/actions/runs/5264997710/jobs/9517035542?pr=1465#step:3:3).8.0
    include-pre-releases: false
Error: Error: unable to get latest version
```

Reference:
- https://github.com/arduino/setup-protoc/pull/78
