### PR TITLE
Task/40 'Permission tests' job runs even if there aren't tests require permission in the repo

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -27,8 +27,11 @@ jobs:
       - name: Test with permissions
         if: ${{ !contains(matrix.os, 'windows') }}
         run: |
-          count=$(go test ./... --list Perm -tags perm | grep Perm | wc -l)
-          echo $count
-          if [ $count -gt 0 ]; then
+          count=0
+          while read -r line ; do
+            [ -n "$(grep -l "Perm" $line)" ] && count=1 && break
+          done < <(grep -R "build perm" --include="*_test.go" -l .)
+          if [ $count == 1 ]; then
+            echo "Found tests with permissions"
             sudo -E PATH="$PATH" bash -c "go test -race -run Perm ./... -tags=perm"
           fi


### PR DESCRIPTION
https://github.com/networkservicemesh/.github/issues/40

"Permission tests" job runs even if there aren't tests require permission in the repo