### PR TITLE
Fix docker-release workflow

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v4
         with:
-          ref: refs/heads/${{ github.event.workflow_run.head_branch }}
+          ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: "Set up Docker Buildx"
         uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
Issue: https://github.com/networkservicemesh/integration-tests/issues/3390

Most likely "refs/heads/" is an extra part.

Builds examples with this fix:
Release branch: https://github.com/glazychev-art/cmd-nsc/actions/runs/8243517246/job/22544246555
Main branch: https://github.com/glazychev-art/cmd-return/actions/runs/8233152060/job/22512031364