### PR TITLE
Add env check job definition

### DIFF
--- a/.github/workflows/env-check.yaml
+++ b/.github/workflows/env-check.yaml
@@ -1,0 +1,23 @@
+---
+name: Env check
+on:
+  workflow_call:
+    inputs:
+      prefix:
+        description: "Env parameter prefix"
+        required: true
+        default: "NSM_"
+        type: string
+jobs:
+  check-env:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: networkservicemesh/.github
+          path: .github
+      - uses: actions/checkout@v4
+        with:
+          path: cmd
+      - name: run-envcheck
+        run: .github/scripts/env-check.sh cmd ${{ inputs.prefix }}

--- a/scripts/env-check.sh
+++ b/scripts/env-check.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ "$#" -lt 1 ]]; then
+    echo "Usage: $(basename "$0") <repo> [env_prefix (default: NSM_)]"
+    exit 1
+fi
+
+repo="$(readlink -e "$1")"
+env_prefix="${2:-NSM_}"
+cmd_name="cmd"
+
+
+is_in_order() {
+    local -a arr
+    mapfile -t arr < <(echo -en "${1}\n${2}" | sort)
+
+    if [[ "${arr[0]}" == "$1" ]]; then
+        return 0
+    fi
+    return 1
+}
+
+print_mismatch() {
+    echo "Mismatch, no ${1} environment variable found in ${2}"
+}
+
+build_cmd() {
+    local -r repo="$1"
+    local -r output="$2"
+    pushd . &>/dev/null
+    cd "$repo"
+    go build -o "$output" .
+    popd &>/dev/null
+}
+
+
+declare -a readme_envs
+mapfile -t readme_envs < <(grep -Eo "${env_prefix}\w+" "${repo}/README.md" | uniq | sort)
+
+
+build_cmd "$repo" "$cmd_name"
+declare -a cmd_envs
+# Since this runs on "ubuntu-runner" I can be sure that no env vars are set and cmd fails
+mapfile -t cmd_envs < <( "${repo}/${cmd_name}" 2>&1 | grep -Eo "${env_prefix}\w+" | uniq | sort)
+
+
+i=0
+j=0
+fail=0
+while true; do
+
+    if [[ "$i" -ge "${#cmd_envs[@]}" ]]; then
+        break
+    elif [[ "$j" -ge "${#readme_envs[@]}" ]]; then
+        break
+    elif [[ "${cmd_envs[$i]}" == "${readme_envs[$j]}" ]]; then
+        ((i+=1));((j+=1))
+    elif is_in_order "${cmd_envs[$i]}" "${readme_envs[$j]}" ; then
+        print_mismatch "${cmd_envs[$i]}" "README.md"
+        ((i+=1))
+        fail=1
+    else
+        print_mismatch "${readme_envs[$j]}" "$cmd_name"
+        ((j+=1))
+        fail=1
+    fi
+done
+
+for ((;i<${#cmd_envs[@]};++i)); do
+    print_mismatch "${cmd_envs[$i]}" "README.md"
+done
+for ((;j<${#readme_envs[@]};++j)); do
+    print_mismatch "${readme_envs[$j]}" "$cmd_name"
+done
+
+
+exit "$fail"


### PR DESCRIPTION
This job checks whether the env variables defined in the cmd-*, and the envs described in the README match.

Issue: #65 

Description:
So basically I made script that for now greps out the envs from cmd, and README, and compares whether these match
There was one repo (cmd-registry-memory) where the prefix was not NSM_, so I made it configurable.
I'm a bit unsure whether the bash script itself is in a good place here, so if you guys know a better place please tell me :)

Usage wise this is only the job, so it should be called from the specific cmd's workflow
There are a few example executions here on Nordix: https://github.com/Nordix/nsm-cmd-forwarder-sriov/actions




