### PR TITLE
Remove some steps from resolve-conflicts workflow

### DIFF
--- a/.github/workflows/resolve-conflicts.yaml
+++ b/.github/workflows/resolve-conflicts.yaml
@@ -34,12 +34,6 @@ jobs:
             echo "Conflicts can be resolved only in go.mod and go.sum files, but conflicts were found in other files: $CONFLICTING_FILES"
             exit 1
           fi
-      - name: Check number of retries
-        run: |
-          if [ $(git log --oneline | head -n 10 | grep -Fc "Automatically resolving conflicts in go.mod") -ge 3 ]; then
-            echo "Couldn't automatically resolve conflicts (number of re-tries is >= 3). Please, resolve them manually."
-            exit 1
-          fi
       - name: Merge default branch
         run: |
           git config --global user.email "nsmbot@networkservicmesh.io"


### PR DESCRIPTION
## Description
Remove an unneeded condition from `resolve-conflict` workflow. This condition checks if the workflow has already tried to resolve conflicts in previous 10 commits. The problem is if a PR has less then 10 commits then the condition also checks `main` branch. If there are resolved conflicts from other PRs in the main branch they will be taken into account too. Therefore, sometimes this workflow doesn't work because of other PRs.
## Issue
https://github.com/networkservicemesh/cmd-forwarder-vpp/pull/1102