### PR TITLE
Checkout default branch (not release branch) of `deployments-k8s` in `release-deployments` workflow

### DIFF
--- a/.github/workflows/release-deployments.yaml
+++ b/.github/workflows/release-deployments.yaml
@@ -33,7 +33,6 @@ jobs:
           path: networkservicemesh/deployments-k8s
           repository: networkservicemesh/deployments-k8s
           token: ${{ secrets.token }}
-          ref: release/${{ inputs.tag }}
 
       - name: Find and Replace ci/${{ github.repository }} version
         uses: jacobtomlinson/gha-find-replace@master


### PR DESCRIPTION
## Fixes
https://github.com/networkservicemesh/cmd-nsmgr/actions/runs/9150114827/job/25154508125