### PR TITLE
Fix PR body construction in pr-for-updates workflow

### DIFF
--- a/.github/workflows/pr-for-updates.yaml
+++ b/.github/workflows/pr-for-updates.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Construct PR message
         run: |
-          PULL_REQUEST_BODY=$(git log --pretty='format:%B' -1 | sed '/^$/d;$d' | sed 's/#/# /g')
+          PULL_REQUEST_BODY=$(git log --format="%s%nCommit: %h%nAuthor: %an%nDate: %ad" -n 1')
           echo "$PULL_REQUEST_BODY"
           echo "PULL_REQUEST_BODY<<EOF" >> $GITHUB_ENV
           echo "$PULL_REQUEST_BODY" >> $GITHUB_ENV


### PR DESCRIPTION
## Description
Change PR Body format so it doesn't print `Message` field of a commit. It significantly reduces PR body size. Example of a new format:
```bash
Update go.mod and go.sum to latest version from networkservicemesh/deployments-k8s@main PR link: https://github.com/networkservicemesh/deployments-k8s/pull/12062
Commit: 3fb933985
Author: NSMBot
Date: Fri May 31 10:06:04 2024 +0000
```

## Issue
https://github.com/networkservicemesh/integration-tests/actions/runs/9316488700/job/25646799956#step:5:933