### PR TITLE
Fix automatically generated release notes too long problem

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,10 +17,32 @@ jobs:
           branch=${{github.event.workflow_run.head_branch}}
           echo tag=${branch#release/} >> $GITHUB_OUTPUT
         id: get-tag-step
+  get-rel-notes:
+    name: Get release notes
+    needs: get-tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: networkservicemesh/.github
+          path: github
+      - name: Install node modules
+        run: yarn add @actions/github
+      - name: Generate Release Notes
+        id: generate-release-notes
+        run: |
+            ls -ltr github/scripts
+            node github/scripts/generate-release-notes.js '${{ secrets.token }}' '${{ needs.get-tag.outputs.tag }}' '${{ github.event.repository.name }}' > notes.txt
+      - name: Upload notes for release
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-notes
+          path: notes.txt
 
   create-release:
     name: Create release
-    needs: get-tag
+    needs: [get-tag, get-rel-notes]
     runs-on: ubuntu-latest
     steps:
       - name: Choose branch
@@ -38,14 +60,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: refs/heads/${{ steps.branch.outputs.branch }}
-
       - name: Push tag ${{ needs.get-tag.outputs.tag }}
         run: |
           git status
           git tag ${{ needs.get-tag.outputs.tag }}
           git push origin ${{ needs.get-tag.outputs.tag }} -f
+      - name: Download release notes
+        uses: actions/download-artifact@v4
+        with:
+          name: release-notes
       - name: Create release ${{ needs.get-tag.outputs.tag }}
         run: |
-          gh release create ${{ needs.get-tag.outputs.tag }} --title ${{ needs.get-tag.outputs.tag }} --target ${{github.event.workflow_run.head_branch}} --generate-notes
+          gh release create ${{ needs.get-tag.outputs.tag }} --title ${{ needs.get-tag.outputs.tag }} --target ${{github.event.workflow_run.head_branch}} --notes-file notes.txt
         env:
           GH_TOKEN: ${{ secrets.token }}

--- a/scripts/generate-release-notes.js
+++ b/scripts/generate-release-notes.js
@@ -1,0 +1,73 @@
+// ./tools/scripts/generate-release-notes.js
+
+const github = require('@actions/github');
+
+/**
+ * Generates the release notes for a github release.
+ *
+ * Arguments:
+ * 1 - github_token
+ * 2 - new version
+ */
+const token = process.argv[2];
+const version = process.argv[3];
+const repo = process.argv[4];
+
+async function main() {
+  const client = github.getOctokit(token);
+
+  const latestReleaseResponse = await client.request(
+    'GET /repos/{owner}/{repo}/releases/latest',
+    {
+      owner: 'networkservicemesh',
+      repo: repo,
+      headers: {
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    }
+  );
+  const previousTag = latestReleaseResponse.data?.tag_name;
+
+  const response = await client.request(
+    'POST /repos/{owner}/{repo}/releases/generate-notes',
+    {
+      owner: 'networkservicemesh',
+      repo: repo,
+      tag_name: version,
+      previous_tag_name: previousTag,
+      headers: {
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    }
+  );
+
+  const noteSections = response.data.body?.split('\n\n');
+  const trimmedSections = [];
+  const githubNotesMaxCharLength = 125000;
+  const maxSectionLength = githubNotesMaxCharLength / noteSections.length;
+  for (let i = 0; i < noteSections.length; i++) {
+    if (noteSections[i].length > githubNotesMaxCharLength) {
+      const lastLineIndex =
+        noteSections[i].substring(0, maxSectionLength).split('\n').length - 1;
+      const trimmed =
+        noteSections[i]
+          .split('\n')
+          .slice(0, lastLineIndex - 1)
+          .join('\n') +
+        `\n... (+${
+          noteSections[i].split('\n').length - (lastLineIndex + 1)
+        } others)`;
+      trimmedSections.push(trimmed);
+      continue;
+    }
+
+    trimmedSections.push(noteSections[i]);
+  }
+
+  console.log(trimmedSections.join('\n\n'));
+}
+
+main().catch((e) => {
+  console.error(`Failed generating release notes with error: ${e}`);
+  process.exit(0);
+});


### PR DESCRIPTION
This is a workaround for the problem described in the issue networkservicemesh/deployments-k8s#12680

A new job added to generate the release notes and trim if needed. The new job is running before release and release use the trimmed release notes instead the automatically generated.