### PR TITLE
Enable dependabot for updating github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+---
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+    groups:
+      gh-actions-minor:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,10 @@
 ---
-# Set update schedule for GitHub Actions
-
 version: 2
 updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every week
       interval: "weekly"
     groups:
       gh-actions-minor:
@@ -15,3 +12,5 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    commit-message:
+      prefix: "[github-actions] "


### PR DESCRIPTION
This PR enables Dependabot in the repository to automatically check GitHub Actions versions weekly and create pull requests for any outdated dependencies found.