### PR TITLE
Uplift golangci-lint to match Go version

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -6,7 +6,7 @@ on:
       linter-version:
         description: version of golangci-lint
         type: string
-        default: v1.60.3
+        default: v1.64.2
         required: false
 jobs:
   golangci-lint:
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.3
+          go-version: 1.24.0
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:


### PR DESCRIPTION
This PR uplifts `golangci-lint` to `v1.64.2` in order to match the Go version `1.24.0`.