### PR TITLE
Pin @actions/github@5 in release workflow to fix Node 20 module error

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,12 +28,12 @@ jobs:
           repository: networkservicemesh/.github
           path: github
       - name: Install node modules
-        run: yarn add @actions/github
+        run: yarn add @actions/github@5
       - name: Generate Release Notes
         id: generate-release-notes
         run: |
-            ls -ltr github/scripts
-            node github/scripts/generate-release-notes.js '${{ secrets.token }}' '${{ needs.get-tag.outputs.tag }}' '${{ github.event.repository.name }}' > notes.txt
+          ls -ltr github/scripts
+          node github/scripts/generate-release-notes.js '${{ secrets.token }}' '${{ needs.get-tag.outputs.tag }}' '${{ github.event.repository.name }}' > notes.txt
       - name: Upload notes for release
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
The release workflow was failing with ERR_PACKAGE_PATH_NOT_EXPORTED when running `generate-release-notes.js` .

This happens because newer versions of `@actions/github` are ESM-only and do not support `require()`, which our script uses. GitHub runners now use Node 20, which strictly enforces package exports.

Pinning `@actions/github` to `v5` restores `CommonJS` compatibility and fixes the release notes generation step.